### PR TITLE
認証画面のデザイン修正

### DIFF
--- a/ios-auth-flow-sample/Presentation/Auth/SignUpViewController.swift
+++ b/ios-auth-flow-sample/Presentation/Auth/SignUpViewController.swift
@@ -182,16 +182,12 @@ class SignUpViewController: UIViewController {
         
         viewModel.$emailValidationError
             .receive(on: RunLoop.main)
-            .sink { [unowned self] errorMessage in
-                emailValidationResultLabel.text = errorMessage
-            }
+            .assign(to: \.text, on: emailValidationResultLabel)
             .store(in: &cancellables)
         
         viewModel.$passwordValidationError
             .receive(on: RunLoop.main)
-            .sink { [unowned self] errorMessage in
-                passwordValidationResultLabel.text = errorMessage
-            }
+            .assign(to: \.text, on: passwordValidationResultLabel)
             .store(in: &cancellables)
         
         

--- a/ios-auth-flow-sample/Presentation/Auth/SignUpViewController.swift
+++ b/ios-auth-flow-sample/Presentation/Auth/SignUpViewController.swift
@@ -174,7 +174,9 @@ class SignUpViewController: UIViewController {
             .receive(on: RunLoop.main)
             .sink { [unowned self] isEnabled in
                 signUpButton.isEnabled = isEnabled
-                signUpButton.backgroundColor = isEnabled ? .magenta : .gray
+                UIView.animate(withDuration: 0.3) {
+                    self.signUpButton.backgroundColor = isEnabled ? .magenta : .gray
+                }
             }
             .store(in: &cancellables)
         

--- a/ios-auth-flow-sample/Presentation/Auth/SignUpViewController.swift
+++ b/ios-auth-flow-sample/Presentation/Auth/SignUpViewController.swift
@@ -115,12 +115,22 @@ class SignUpViewController: UIViewController {
                 views: ["emailValidationResultLabel": emailValidationResultLabel]
             )
             + NSLayoutConstraint.constraints(
+                withVisualFormat: "V:[emailValidationResultLabel(12)]",
+                metrics: nil,
+                views: ["emailValidationResultLabel": emailValidationResultLabel]
+            )
+            + NSLayoutConstraint.constraints(
                 withVisualFormat: "|[textField]|",
                 metrics: nil,
                 views: ["textField": passwordTextField]
             )
             + NSLayoutConstraint.constraints(
                 withVisualFormat: "|[passwordValidationResultLabel]|",
+                metrics: nil,
+                views: ["passwordValidationResultLabel": passwordValidationResultLabel]
+            )
+            + NSLayoutConstraint.constraints(
+                withVisualFormat: "V:[passwordValidationResultLabel(12)]",
                 metrics: nil,
                 views: ["passwordValidationResultLabel": passwordValidationResultLabel]
             )


### PR DESCRIPTION
## 概要
- SIGN UPボタンの有効性の切り替えをアニメーション対応
- Email/Passwordテキストのバリデーションエラー表示による高さ固定

## 詳細

### SIGN UPボタンの有効性の切り替えをアニメーション対応
https://github.com/mothule/ios-auth-flow-sample/assets/974367/002e70dd-4fd8-440c-85c4-8395e8c1cdcc

#### 修正内容
sink内でUIView.animateメソッドを使いボタン背景色を変更。



### Email/Passwordテキストのバリデーションエラー表示による高さ固定
|Before|After|
|---|---|
|<img width="565" alt="image" src="https://github.com/mothule/ios-auth-flow-sample/assets/974367/63e575a0-f5cb-49a1-95f3-5a98bbc5cc81">|<img width="565" alt="image" src="https://github.com/mothule/ios-auth-flow-sample/assets/974367/0281f0d6-48cd-4b60-b911-afcec01771f2">|

#### 修正内容
バリデーションラベルの高さを固定。

